### PR TITLE
Replaced all deprecated PyPDF2 methods

### DIFF
--- a/PDF Trimmer/pdf_trimmer.py
+++ b/PDF Trimmer/pdf_trimmer.py
@@ -15,32 +15,32 @@ else:   # Replace the same file
 
 
 # Initialize PDF reader & writer objects
-in_file = PyPDF2.PdfFileReader(in_fpath, 'rb') 
-out_file = PyPDF2.PdfFileWriter()
+in_file = PyPDF2.PdfReader(in_fpath, 'rb') 
+out_file = PyPDF2.PdfWriter()
 
 # To extract text from a PDF page
 def extract_text(pageObj):
     # Works fine for PDFs I tested with, yet it may fail for others
     # See: https://stackoverflow.com/questions/34837707/how-to-extract-text-from-a-pdf-file
-    text = pageObj.extractText()
+    text = pageObj.extract_text()
     return re.sub('[\n\r\s]+', '', text)
 
 
-prev_pg_text = extract_text(in_file.getPage(0))
+prev_pg_text = extract_text(in_file.pages[0])
 del_pages = []
 
-for pgNo in range(1, in_file.numPages):
-    pg_text = extract_text(in_file.getPage(pgNo))
+for pgNo in range(1, len(in_file.pages)):
+    pg_text = extract_text(in_file.pages[pgNo])
     # If current page contains all text of previous page
     if pg_text.startswith(prev_pg_text):
         del_pages.append(pgNo-1) # Delete previous page
     prev_pg_text = pg_text
 
 # To delete pages, have to write a new PDF excluding those
-for pgNo in range(in_file.numPages):
+for pgNo in range(len(in_file.pages)):
     if pgNo not in del_pages:
-        pg = in_file.getPage(pgNo)
-        out_file.addPage(pg)
+        pg = in_file.pages[pgNo]
+        out_file.add_page(pg)
   
 with open(out_fpath, 'wb') as f:
     out_file.write(f)


### PR DESCRIPTION
The current version of PyPDF2 does not support some methods like `PdfFileReader()` anymore. Replaced all deprecated methods that prevented the script from running